### PR TITLE
Disable at-rule-empty-line-before

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
 	rules: {
+		'at-rule-empty-line-before': null,
 		'scss/at-else-closing-brace-newline-after': null,
 		'scss/at-else-closing-brace-space-after': null,
 		'scss/at-else-empty-line-before': null,


### PR DESCRIPTION
This rule was originally disabled by stylelint-config-prettier, before we removed it: https://github.com/prettier/stylelint-config-prettier/blob/master/src/index.js#LL8C3-L8C37

However, stylelint-config-standard-scss explicitly enables it as a stylistic rule, even though it's not a rule provided by stylelint-scss: https://github.com/stylelint-scss/stylelint-config-standard-scss/blob/main/index.js#L6

Therefore, we now need to explicitly disable it to keep it from conflicting with prettier.

Fixes #5 